### PR TITLE
Clarify the license of the project

### DIFF
--- a/expand-open.opam
+++ b/expand-open.opam
@@ -7,7 +7,7 @@ A utility to expand module names in OCaml programs
 """
 maintainer: "Kenichi Asai <asai@is.ocha.ac.jp>"
 authors: "Kenichi Asai <asai@is.ocha.ac.jp>"
-license: "MIT"
+license: "MIT AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/kenichi-asai/expand-open"
 bug-reports: "https://github.com/kenichi-asai/expand-open/issues"
 depends: [ "ocaml" "ocamlfind" "dune" ]


### PR DESCRIPTION
This project includes code under LGPL (from the OCaml compiler) and i believe these can't be "downgraded" to the more permissive MIT license so this change makes it explicit in the opam file.

I think the LGPL license in question should probably be also present in the LICENSE file since the header makes reference to it